### PR TITLE
Multiples

### DIFF
--- a/4/multiples/multiples.rb
+++ b/4/multiples/multiples.rb
@@ -1,7 +1,18 @@
 def customized_list_of_multiples(multiples_of, size)
   list = Array.new(size) { |index| (index + 2) * multiples_of }
-  yield(list) if block_given?
-  # need to add this as yield evaluated as nil if no block given
-  # and nil returned
-  list
+  if block_given?
+    yield list
+  else
+    # need to add this as yield evaluated as nil if no block given
+    # and nil returned
+    list
+  end
 end
+
+p customized_list_of_multiples(3, 6)
+
+p customized_list_of_multiples(3, 6) { |arr| arr.map(&:to_s) }
+
+doubler = proc { |el| el * 2 }
+p customized_list_of_multiples(3, 6) { |arr| arr.map(&doubler) }
+

--- a/4/multiples/multiples.rb
+++ b/4/multiples/multiples.rb
@@ -16,3 +16,9 @@ p customized_list_of_multiples(3, 6) { |arr| arr.map(&:to_s) }
 doubler = proc { |el| el * 2 }
 p customized_list_of_multiples(3, 6) { |arr| arr.map(&doubler) }
 
+# block_given? returns false for this
+# Because print method call only passes the first line of code to prin
+# Need to add parenthesis ()
+print customized_list_of_multiples(3, 6) do |arr|
+  arr.map(&doubler)
+end

--- a/4/multiples/multiples.rb
+++ b/4/multiples/multiples.rb
@@ -1,0 +1,7 @@
+def customized_list_of_multiples(multiples_of, size)
+  list = Array.new(size) { |index| (index + 2) * multiples_of }
+  yield(list) if block_given?
+  # need to add this as yield evaluated as nil if no block given
+  # and nil returned
+  list
+end


### PR DESCRIPTION
One of the reasons to use blocks is to execute user-provided code in the middle of a method. Using a parameter wouldn’t do the trick in this case, because the code would execute before the method is called and the result would be passed in as an argument.

- [x] Write a method called customized_list_of_multiples that has a parameter called multiples_of and size. Inside the method, create a list with a maximum length of size. Then, if a block is given (hint: see block_given?), yield to that block passing in the list you created. The method should either return whatever the block returned, or the list of multiples you created if there was no block. Make a commit.

- [x] At the bottom of the file, call customized_list_of_multiples without a block, and then at least twice more passing in a different block each time. Ensure that the blocks actually change the list of multiples in some way before returning it. Make a commit.

